### PR TITLE
remove vim from makedepends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,7 +8,6 @@ pkgdesc='Console-based Audio Visualizer for Alsa'
 arch=('any')
 url='https://github.com/karlstav/cava'
 license=('MIT')
-makedepends=('vim')
 depends=('fftw' 'alsa-lib' 'ncurses' 'iniparser')
 optdepends=('sndio' 'pulseaudio' 'portaudio')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/karlstav/cava/archive/${pkgver}.tar.gz")


### PR DESCRIPTION
Hi there,
saw that vim (and by extension vim-runtime) crept in as a depend.
I don't want that editor installed at all, so I checked to see if it was actually needed and then whipped it out of there. The build progressed and completed as expected with just this change and that is why I'm submitting this PR.

Thanks,
RetroRodent
