### PR TITLE
add sndio, portaudio and libpulse to makedepends

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -3,13 +3,14 @@
 
 pkgname=cava
 pkgver=0.8.2
-pkgrel=3
+pkgrel=4
 pkgdesc='Console-based Audio Visualizer for Alsa'
 arch=('any')
 url='https://github.com/karlstav/cava'
 license=('MIT')
-depends=('fftw' 'pulseaudio' 'alsa-lib' 'ncurses' 'iniparser')
-optdepends=('sndio' 'portaudio')
+depends=('fftw' 'alsa-lib' 'ncurses' 'iniparser')
+optdepends=('sndio' 'portaudio' 'pulseaudio')
+makedepends=('sndio' 'portaudio' 'libpulse')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/karlstav/cava/archive/${pkgver}.tar.gz")
 sha512sums=('8ab146987324fad97dea5e9fd893de6c12b00cbb074d835c1e334d75c0d32cb4cbbc13cf72f7899191ebd5d346505b2639dcad5312e5ab00975b29a006ba41b3')
 


### PR DESCRIPTION
This PR fix #1, #6, #7 and d948a5c6b00b999ba8ba5ddfd532e386e22fa3bd.

Adding as optdepends don't cause cava to be built with support for sndio, portaudio and pulseaudio, we need the dev files during build time. And given cava don't really depends on any of them, we should not add sndio, portaudio or pulseaudio to _depends_, but add to _makedepends_ instead.

Changes:
1. The commit title of d948a5c6b00b999ba8ba5ddfd532e386e22fa3bd say "Add pulseaudio to makedepends", but instead it include pulseaudio to _depends_, so properly add pulseaudio (libpulse) to _makedepends_.

2. If we build in a clean chroot, cava get built without support for sndio and portaudio, fix this including sndio and portaudio to _makedepends_, we will get rid of these build warnings:
```
checking for Pa_Initialize in -lportaudio... no
configure: WARNING: No portaudio dev files found building without portaudio support
checking for sio_open in -lsndio... no
configure: WARNING: No sndio dev files found building without sndio support
```

3. "Revert" d948a5c6b00b999ba8ba5ddfd532e386e22fa3bd as explained above, move pulseaudio back to optdepends.