### PR TITLE
Update PKGBUILD to v0.10.1

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Ex-Maintainer: Celestial Walrus <aur@celestial.cf>
 
 pkgname=cava
-pkgver=0.10.0
+pkgver=0.10.1
 pkgrel=1
 pkgdesc='Console-based Audio Visualizer for Alsa'
 arch=('any')
@@ -12,7 +12,7 @@ depends=('fftw' 'alsa-lib' 'ncurses' 'iniparser' 'sndio' 'portaudio')
 optdepends=('pulseaudio')
 makedepends=('sndio' 'portaudio' 'libpulse' 'm4' 'automake' 'autoconf')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/karlstav/cava/archive/${pkgver}.tar.gz")
-sha512sums=('8b54ed59ce7965209f0e03be3409f59b0e59e6a684afca3eb2e3c82c369d35224a0a1a09cbcbca09b36fce416a13efafdff7362fe0b4e2f6b494a023de76793e')
+sha512sums=('8a71628bae6621ef925f5fed94659b07d9220e142c17514bed79e1105a9160494bf3978267c9de3ab6cd2126ece50419fb4245ccf190f3a299fc0cfb111be354')
 
 build() {
   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
This version fix sndio source handling in cava

This commit resolves the issue where cava default to sndio before pulseaudio if both are present, resulting in errors such as:

- couldn't open rec stream: No such file or directory
- input/sndio.c: Could not open sndio source: default

The fix involves prioritizing pulseaudio over sndio.

See: https://github.com/karlstav/cava/commit/a84e2500d7d9d7c44bef8d9b224092a4435d573b